### PR TITLE
Localize escape prototype to Japanese

### DIFF
--- a/prototype/README.md
+++ b/prototype/README.md
@@ -1,13 +1,26 @@
-# Escape Room Prototype
+# Codex 脱出アドベンチャー プロトタイプ
 
-This directory contains a very simple web-based prototype for a 2D adventure/escape game. Open `index.html` in a web browser to play.
+このディレクトリには、**gamedevelopplan** を指針として構築したレトロ風ポイント＆クリック脱出ゲームのブラウザ用プロトタイプが含まれています。
 
-## How it Works
-- The room is represented by a static image (`room.svg`).
-The image is a simple inline SVG so that no binary assets are needed.
+## プレイ方法
+1. プロジェクト直下で `python -m http.server --bind 0.0.0.0 8000` を実行し、静的ホストを立ち上げます。
+2. 同じネットワーク上の PC またはスマートフォンから `http://<あなたのIP>:8000/index.html` にアクセスします。
+3. **行動** パネルで動詞を選び、シーン内で強調表示されたホットスポットをクリック／タップします。
+4. **アイテム** パネルで使用したいアイテムを準備してから **使う** を選びます。
+5. **記録** に表示されるログテキストで物語の反応やヒントを確認します。
 
-- Clickable hotspots are positioned over the image using absolute positioning.
-- Clicking the box gives you a key that appears in the inventory list.
-- Clicking the door checks the inventory. If you have the key, you escape and the game ends.
+> **ヒント:** スマートフォンではタイトル下のタブバーから 行動／アイテム／記録 パネルを切り替えられるため、狭い画面でも快適に操作できます。
 
-No external dependencies are required; everything runs in the browser with plain HTML, CSS, and JavaScript.
+## シナリオ概要
+- **書斎:** 机と肖像画を調べて脱出に役立つ道具を見つけましょう。
+- **廊下:** 木箱をこじ開け、鉄格子の錠を解きます。
+- **玄関ホール:** 玄関を抜ければ脱出成功です。
+
+プロトタイプには 3 枚の SVG 背景（`scenes/study.svg`、`scenes/hallway.svg`、`scenes/foyer.svg`）が含まれています。独自アートへ差し替える場合はファイルを入れ替えるか、`main.js` 内のパスを書き換えてください。音声素材は同梱されていませんが、ログ出力部分に効果音再生処理を追加できる構造になっています。
+
+## 実装メモ
+- セマンティックな HTML とレスポンシブな CSS、素の JavaScript で構成されています。
+- 動詞／アイテム／シーン／ホットスポット／フラグといったゲームデータは素早く編集できるよう `main.js` にまとめています。
+- アイテムと動詞の選択は Enter／Space キーでも操作可能です。
+
+ビルドツールや外部ライブラリは不要です。

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1,25 +1,54 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Escape Room Prototype</title>
-<link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Codex 脱出アドベンチャー</title>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-<div id="game">
-  <div id="scene-container">
-    <img id="scene-image" src="room.svg" alt="Room" />
-    <div id="hotspots"></div>
+  <div id="game">
+    <header>
+      <h1>Codex 脱出アドベンチャー</h1>
+      <p class="subtitle">企画書に基づいて組み立てたポイント＆クリック型パズル。</p>
+    </header>
+    <nav id="mobile-nav" aria-label="Interface panels">
+      <button type="button" class="mobile-tab" data-panel-target="actions" aria-controls="actions-panel" aria-pressed="true">
+        行動
+      </button>
+      <button type="button" class="mobile-tab" data-panel-target="inventory" aria-controls="inventory" aria-pressed="false">
+        アイテム
+      </button>
+      <button type="button" class="mobile-tab" data-panel-target="journal" aria-controls="journal" aria-pressed="false">
+        記録
+      </button>
+    </nav>
+    <main class="layout">
+      <aside id="actions-panel">
+        <h2>行動</h2>
+        <div id="verb-buttons" class="button-column"></div>
+        <p class="hint">動詞を選び、対象をクリックしてください。<br />「使う」はアイテムの準備が必要です。</p>
+      </aside>
+      <section id="scene-wrapper">
+        <div id="scene-container">
+          <img id="scene-image" src="" alt="Scene" />
+          <div id="hotspots"></div>
+        </div>
+        <div id="scene-caption"></div>
+      </section>
+      <aside id="sidebar">
+        <section id="inventory">
+          <h2>アイテム</h2>
+          <ul id="inventory-list"></ul>
+          <p class="hint">クリックすると「使う」で指定できます。</p>
+        </section>
+        <section id="journal">
+          <h2>記録</h2>
+          <div id="text-log"></div>
+        </section>
+      </aside>
+    </main>
   </div>
-  <div id="ui">
-    <div id="inventory">
-      <h3>Inventory</h3>
-      <ul id="inventory-list"></ul>
-    </div>
-    <div id="text-box"></div>
-  </div>
-</div>
-<script src="main.js"></script>
+  <script src="main.js"></script>
 </body>
 </html>

--- a/prototype/main.js
+++ b/prototype/main.js
@@ -1,84 +1,608 @@
-const gameData = {
-  scene: 'room',
-  inventory: [],
-  scenes: {
-    room: {
-      image: 'room.svg',
-      hotspots: [
-        {
-          id: 'box',
-          x: 250,
-          y: 220,
-          width: 100,
-          height: 60,
-          onClick: () => openBox()
-        },
-        {
-          id: 'door',
-          x: 520,
-          y: 120,
-          width: 80,
-          height: 180,
-          onClick: () => tryDoor()
-        }
-      ]
-    }
+const verbs = [
+  { id: 'Look', label: '調べる' },
+  { id: 'Open', label: '開ける' },
+  { id: 'Take', label: '取る' },
+  { id: 'Use', label: '使う' },
+  { id: 'Move', label: '移動' }
+];
+
+const itemCatalog = {
+  studyKey: {
+    id: 'studyKey',
+    name: '書斎の鍵',
+    description: '机の引き出しから見つかった古びた鍵。'
+  },
+  crowbar: {
+    id: 'crowbar',
+    name: '細いバール',
+    description: '肖像画の裏に隠されていた軽いバール。'
+  },
+  brassKey: {
+    id: 'brassKey',
+    name: '真鍮の鍵',
+    description: '木箱の中で光っていた装飾付きの鍵。'
   }
 };
 
-const textBox = document.getElementById('text-box');
-const inventoryList = document.getElementById('inventory-list');
-const sceneImage = document.getElementById('scene-image');
-const hotspotsDiv = document.getElementById('hotspots');
+const state = {
+  currentScene: 'study',
+  inventory: [],
+  selectedVerb: 'Look',
+  selectedItemId: null,
+  flags: {},
+  visitedScenes: {}
+};
 
-function showMessage(msg) {
-  textBox.textContent = msg;
+const scenes = {
+  study: {
+    id: 'study',
+    name: '書斎',
+    caption: '埃と古い秘密が沈殿した静かな書斎だ。',
+    entryMessage: '実験が始まった書斎にいる。扉は外側から施錠されている。',
+    image: 'scenes/study.svg',
+    hotspots: [
+      {
+        id: 'desk',
+        name: '執務机',
+        area: { x: 80, y: 300, width: 240, height: 140 },
+        actions: {
+          Look: () => {
+            logMessage('使い込まれたオーク材の机だ。引き出しは膨らんで閉じている。');
+          },
+          Open: () => {
+            if (!state.flags.deskOpened) {
+              state.flags.deskOpened = true;
+              logMessage('力を込めると引き出しが開き、内側で小さな鍵が光った。');
+            } else {
+              logMessage('引き出しはすでに開いている。');
+            }
+          },
+          Take: () => {
+            if (state.flags.deskOpened && !hasItem('studyKey')) {
+              addItem('studyKey');
+              logMessage('書斎の鍵を手に入れた。歯はすり減っている。');
+            } else if (!state.flags.deskOpened) {
+              logMessage('引き出しを引くがびくともしない。');
+            } else {
+              logMessage('机から取れるものはもう残っていない。');
+            }
+          }
+        }
+      },
+      {
+        id: 'portrait',
+        name: '家族の肖像画',
+        area: { x: 360, y: 120, width: 180, height: 220 },
+        actions: {
+          Look: () => {
+            if (!state.flags.portraitShifted) {
+              logMessage('厳しい表情の肖像画がこちらを見下ろしている。額縁が少し傾いているようだ。');
+            } else {
+              logMessage('肖像画は横に開かれており、浅い隙間が露出している。');
+            }
+          },
+          Open: () => {
+            if (!state.flags.portraitShifted) {
+              state.flags.portraitShifted = true;
+              logMessage('額縁を押すと隠し蝶番で回転し、細いバールが現れた。');
+            } else {
+              logMessage('隠しスペースはすでに露出している。');
+            }
+          },
+          Take: () => {
+            if (state.flags.portraitShifted && !hasItem('crowbar')) {
+              addItem('crowbar');
+              logMessage('細いバールを取った。固いものをこじ開けるのに良さそうだ。');
+            } else if (!state.flags.portraitShifted) {
+              logMessage('絵を探るが何も起こらない。');
+            } else {
+              logMessage('隙間にはもう何も残っていない。');
+            }
+          }
+        }
+      },
+      {
+        id: 'studyDoor',
+        name: '書斎の扉',
+        area: { x: 820, y: 160, width: 100, height: 240 },
+        actions: {
+          Look: () => {
+            if (state.flags.studyDoorUnlocked) {
+              logMessage('扉は少し開き、細い廊下へと続いている。');
+            } else {
+              logMessage('古い錠前が付いた重いオーク材の扉が行く手を塞いでいる。');
+            }
+          },
+          Use: ({ item }) => {
+            if (!item) {
+              logMessage('扉に使う前にアイテムを選ぶ必要がある。');
+              return;
+            }
+            if (item.id === 'studyKey') {
+              if (!state.flags.studyDoorUnlocked) {
+                state.flags.studyDoorUnlocked = true;
+                removeItem('studyKey');
+                logMessage('錠前で鍵が軋むが、ほどなくして解錠された。');
+              } else {
+                logMessage('扉はすでに解錠されている。');
+              }
+            } else {
+              logMessage('そのアイテムでは錠前に変化はない。');
+            }
+          },
+          Move: () => {
+            if (state.flags.studyDoorUnlocked) {
+              changeScene('hallway');
+            } else {
+              logMessage('取っ手はほとんど回らない。まず解錠しなければ。');
+            }
+          }
+        }
+      },
+      {
+        id: 'notes',
+        name: '散らばったメモ',
+        area: { x: 640, y: 340, width: 200, height: 120 },
+        actions: {
+          Look: () => {
+            logMessage('メモには「真実をこじ開ける者だけが夜明けを見る」と記されている。');
+          }
+        }
+      }
+    ]
+  },
+  hallway: {
+    id: 'hallway',
+    name: '廊下',
+    caption: '木箱と鉄格子が並ぶ風の通る廊下だ。',
+    entryMessage: '床板が軋む廊下だ。木箱が鉄格子への道を塞いでいる。',
+    image: 'scenes/hallway.svg',
+    hotspots: [
+      {
+        id: 'backDoor',
+        name: '書斎への扉',
+        area: { x: 60, y: 160, width: 120, height: 240 },
+        actions: {
+          Look: () => {
+            logMessage('書斎へ戻る扉はもう自由に開閉できる。');
+          },
+          Move: () => {
+            changeScene('study');
+          }
+        }
+      },
+      {
+        id: 'crate',
+        name: '木箱',
+        area: { x: 320, y: 300, width: 200, height: 150 },
+        actions: {
+          Look: () => {
+            if (!state.flags.crateOpened) {
+              logMessage('木箱は釘で固く閉じられている。中で何かが揺れる音がする。');
+            } else {
+              logMessage('木箱はこじ開けられ、藁の中に真鍮の鍵が見えている。');
+            }
+          },
+          Use: ({ item }) => {
+            if (!item) {
+              logMessage('木箱をこじ開けるためのアイテムを選ぶ必要がある。');
+              return;
+            }
+            if (item.id === 'crowbar') {
+              if (!state.flags.crateOpened) {
+                state.flags.crateOpened = true;
+                logMessage('バールを隙間に差し込みこじ開けると、真鍮の鍵が輝いた。');
+              } else {
+                logMessage('木箱はすでに開いている。');
+              }
+            } else {
+              logMessage('そのアイテムでは木箱はびくともしない。');
+            }
+          },
+          Take: () => {
+            if (state.flags.crateOpened && !hasItem('brassKey')) {
+              addItem('brassKey');
+              logMessage('木箱から真鍮の鍵を取り出した。');
+            } else if (!state.flags.crateOpened) {
+              logMessage('蓋が固すぎて何も取り出せない。');
+            } else {
+              logMessage('木箱に役立つものはもう残っていない。');
+            }
+          }
+        }
+      },
+      {
+        id: 'gate',
+        name: '鉄格子',
+        area: { x: 700, y: 150, width: 160, height: 250 },
+        actions: {
+          Look: () => {
+            if (state.flags.foyerUnlocked) {
+              logMessage('鉄格子は開いており、その先に玄関ホールが見える。');
+            } else {
+              logMessage('鉄の格子には装飾的な錠前が付いている。向こう側から新鮮な空気が流れ込む。');
+            }
+          },
+          Use: ({ item }) => {
+            if (!item) {
+              logMessage('格子に使うアイテムを先に選んでほしい。');
+              return;
+            }
+            if (item.id === 'brassKey') {
+              if (!state.flags.foyerUnlocked) {
+                state.flags.foyerUnlocked = true;
+                removeItem('brassKey');
+                logMessage('真鍮の鍵がぴたりとはまり、心地よい音を立てて解錠された。');
+              } else {
+                logMessage('格子はすでに開いている。');
+              }
+            } else {
+              logMessage('そのアイテムは錠前に合わない。');
+            }
+          },
+          Move: () => {
+            if (state.flags.foyerUnlocked) {
+              changeScene('foyer');
+            } else {
+              logMessage('格子はびくともしない。まず解錠が必要だ。');
+            }
+          }
+        }
+      },
+      {
+        id: 'sconce',
+        name: '壁の燭台',
+        area: { x: 460, y: 140, width: 120, height: 140 },
+        actions: {
+          Look: () => {
+            logMessage('燭台が揺らめき、影が木箱と鉄格子を指し示すように伸びている。');
+          },
+          Use: () => {
+            logMessage('燭台を動かしてみたが何も起こらない。手がかりは別にあるようだ。');
+          }
+        }
+      }
+    ]
+  },
+  foyer: {
+    id: 'foyer',
+    name: '玄関ホール',
+    caption: '夜の冷たい空気が満ちている静かなホールだ。',
+    entryMessage: '玄関ホールに夜風が流れ込んでいる。自由はもう一歩先だ。',
+    image: 'scenes/foyer.svg',
+    hotspots: [
+      {
+        id: 'backGate',
+        name: '廊下への格子',
+        area: { x: 700, y: 150, width: 160, height: 250 },
+        layer: 2,
+        actions: {
+          Look: () => logMessage('廊下へ戻る格子は開いたままだ。'),
+          Move: () => changeScene('hallway')
+        }
+      },
+      {
+        id: 'frontDoor',
+        name: '玄関扉',
+        area: { x: 360, y: 140, width: 240, height: 280 },
+        layer: 3,
+        actions: {
+          Look: () => {
+            if (state.flags.escaped) {
+              logMessage('開いた扉の向こうに外の世界が広がる。夜は君のものだ。');
+            } else {
+              logMessage('玄関扉は半開きで、外の世界が呼びかけている。');
+            }
+          },
+          Move: () => {
+            if (!state.flags.escaped) {
+              state.flags.escaped = true;
+              logMessage('玄関を踏み越え、外気を大きく吸い込む。Codex 邸からの脱出に成功した！', { highlight: true });
+              displayEnding();
+            } else {
+              logMessage('すでに自由を手に入れている。');
+            }
+          }
+        }
+      },
+      {
+        id: 'nightAir',
+        name: '夜気',
+        area: { x: 470, y: 230, width: 70, height: 110 },
+        actions: {
+          Look: () => {
+            logMessage('扉の向こうで夜空が瞬いている。');
+          },
+          Take: () => {
+            logMessage('夜気を瓶に詰めることはできないが、その冷たさを味わう。');
+          }
+        }
+      }
+    ]
+  }
+};
+
+const verbButtons = document.getElementById('verb-buttons');
+const inventoryList = document.getElementById('inventory-list');
+const textLog = document.getElementById('text-log');
+const sceneImage = document.getElementById('scene-image');
+const sceneCaption = document.getElementById('scene-caption');
+const hotspotsContainer = document.getElementById('hotspots');
+const mobileNav = document.getElementById('mobile-nav');
+const mobileButtons = mobileNav ? Array.from(mobileNav.querySelectorAll('.mobile-tab')) : [];
+const mobilePanels = {
+  actions: document.getElementById('actions-panel'),
+  inventory: document.getElementById('inventory'),
+  journal: document.getElementById('journal')
+};
+const mobileMediaQuery = window.matchMedia('(max-width: 720px)');
+let activeMobilePanel = 'actions';
+
+function applyMobileLayout() {
+  if (!mobileNav) return;
+  const isMobile = mobileMediaQuery.matches;
+  Object.entries(mobilePanels).forEach(([panelId, panel]) => {
+    if (!panel) return;
+    if (isMobile) {
+      const isActive = panelId === activeMobilePanel;
+      panel.hidden = !isActive;
+      panel.classList.toggle('mobile-active', isActive);
+    } else {
+      panel.hidden = false;
+      panel.classList.remove('mobile-active');
+    }
+  });
+
+  mobileButtons.forEach((button) => {
+    const isActive = isMobile && button.dataset.panelTarget === activeMobilePanel;
+    button.classList.toggle('active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    button.tabIndex = isMobile ? 0 : -1;
+  });
+}
+
+function setMobilePanel(panelId) {
+  if (!mobileNav) return;
+  if (!mobilePanels[panelId]) {
+    panelId = 'actions';
+  }
+  activeMobilePanel = panelId;
+  applyMobileLayout();
+}
+
+if (mobileNav) {
+  mobileButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      setMobilePanel(button.dataset.panelTarget);
+    });
+  });
+  const handleMobileChange = () => {
+    if (!mobileMediaQuery.matches) {
+      activeMobilePanel = 'actions';
+    }
+    applyMobileLayout();
+  };
+  if (typeof mobileMediaQuery.addEventListener === 'function') {
+    mobileMediaQuery.addEventListener('change', handleMobileChange);
+  } else if (typeof mobileMediaQuery.addListener === 'function') {
+    mobileMediaQuery.addListener(handleMobileChange);
+  }
+}
+
+function renderVerbs() {
+  verbButtons.innerHTML = '';
+  verbs.forEach((verb) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `verb-button${state.selectedVerb === verb.id ? ' selected' : ''}`;
+    button.textContent = verb.label;
+    button.addEventListener('click', () => selectVerb(verb.id));
+    button.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        selectVerb(verb.id);
+      }
+    });
+    verbButtons.appendChild(button);
+  });
+}
+
+function selectVerb(verbId) {
+  state.selectedVerb = verbId;
+  if (verbId !== 'Use') {
+    state.selectedItemId = null;
+  }
+  renderVerbs();
+  renderInventory();
 }
 
 function renderInventory() {
   inventoryList.innerHTML = '';
-  gameData.inventory.forEach(item => {
+  if (state.inventory.length === 0) {
+    const empty = document.createElement('li');
+    empty.textContent = 'アイテムは所持していない';
+    empty.className = 'empty';
+    empty.style.cursor = 'default';
+    empty.setAttribute('aria-disabled', 'true');
+    inventoryList.appendChild(empty);
+    return;
+  }
+
+  state.inventory.forEach((itemId) => {
+    const item = itemCatalog[itemId];
     const li = document.createElement('li');
-    li.textContent = item;
+    if (state.selectedItemId === itemId) {
+      li.classList.add('selected');
+    }
+
+    const name = document.createElement('span');
+    name.className = 'inventory-name';
+    name.textContent = item.name;
+    li.appendChild(name);
+
+    const description = document.createElement('span');
+    description.className = 'inventory-description';
+    description.textContent = item.description;
+    li.appendChild(description);
+
+    li.tabIndex = 0;
+    li.addEventListener('click', () => toggleItemSelection(itemId));
+    li.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleItemSelection(itemId);
+      }
+    });
+
     inventoryList.appendChild(li);
   });
 }
 
-function loadScene(name) {
-  const scene = gameData.scenes[name];
+function toggleItemSelection(itemId) {
+  if (state.selectedItemId === itemId) {
+    state.selectedItemId = null;
+  } else {
+    state.selectedItemId = itemId;
+    if (state.selectedVerb !== 'Use') {
+      state.selectedVerb = 'Use';
+      renderVerbs();
+    }
+  }
+  renderInventory();
+}
+
+function changeScene(sceneId) {
+  const scene = scenes[sceneId];
+  if (!scene) return;
+  state.currentScene = sceneId;
   sceneImage.src = scene.image;
-  hotspotsDiv.innerHTML = '';
-  scene.hotspots.forEach(h => {
-    const div = document.createElement('div');
-    div.className = 'hotspot';
-    div.style.left = h.x + 'px';
-    div.style.top = h.y + 'px';
-    div.style.width = h.width + 'px';
-    div.style.height = h.height + 'px';
-    div.addEventListener('click', h.onClick);
-    hotspotsDiv.appendChild(div);
+  sceneImage.alt = scene.name;
+  sceneCaption.textContent = scene.caption;
+  renderHotspots(scene);
+  const firstVisit = !state.visitedScenes[sceneId];
+  state.visitedScenes[sceneId] = true;
+  if (scene.entryMessage) {
+    logMessage(scene.entryMessage, { highlight: firstVisit });
+  } else if (firstVisit) {
+    logMessage(`${scene.name}に到着した。`, { highlight: true });
+  } else if (scene.caption) {
+    logMessage(scene.caption);
+  }
+}
+
+function renderHotspots(scene) {
+  hotspotsContainer.innerHTML = '';
+  scene.hotspots.forEach((hotspot) => {
+    const hotspotEl = document.createElement('div');
+    hotspotEl.className = 'hotspot';
+    hotspotEl.style.left = `${hotspot.area.x}px`;
+    hotspotEl.style.top = `${hotspot.area.y}px`;
+    hotspotEl.style.width = `${hotspot.area.width}px`;
+    hotspotEl.style.height = `${hotspot.area.height}px`;
+    hotspotEl.style.zIndex = hotspot.layer ?? 1;
+    hotspotEl.dataset.name = hotspot.name;
+    hotspotEl.title = hotspot.name;
+    hotspotEl.tabIndex = 0;
+    hotspotEl.addEventListener('click', () => handleHotspotInteraction(hotspot));
+    hotspotEl.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleHotspotInteraction(hotspot);
+      }
+    });
+    hotspotsContainer.appendChild(hotspotEl);
   });
-  showMessage('You are in a locked room. Find a way to escape.');
 }
 
-function openBox() {
-  if (!gameData.inventory.includes('Key')) {
-    gameData.inventory.push('Key');
+function handleHotspotInteraction(hotspot) {
+  const verb = state.selectedVerb || 'Look';
+  const scene = scenes[state.currentScene];
+  const context = {
+    scene,
+    hotspot,
+    item: state.selectedItemId ? itemCatalog[state.selectedItemId] : null
+  };
+
+  if (verb === 'Use' && !context.item && hotspot.actions?.Use) {
+    logMessage('先に使用するアイテムを選択してほしい。');
+    return;
+  }
+
+  const action = hotspot.actions?.[verb];
+  if (typeof action === 'function') {
+    action(context);
+    if (verb === 'Use' && context.item && !hasItem(context.item.id)) {
+      state.selectedItemId = null;
+      renderInventory();
+      renderVerbs();
+    }
+    return;
+  }
+
+  if (verb === 'Take') {
+    logMessage('ここで取れるものはない。');
+    return;
+  }
+
+  if (verb === 'Move') {
+    logMessage('その方向へは進めない。');
+    return;
+  }
+
+  logMessage('特に変化は起こらなかった。');
+}
+
+function logMessage(message, options = {}) {
+  const entry = document.createElement('div');
+  entry.className = 'log-entry';
+  if (options.highlight) {
+    const strong = document.createElement('strong');
+    strong.textContent = message;
+    entry.appendChild(strong);
+  } else {
+    entry.textContent = message;
+  }
+  textLog.appendChild(entry);
+  textLog.scrollTop = textLog.scrollHeight;
+}
+
+function addItem(itemId) {
+  if (!hasItem(itemId)) {
+    state.inventory.push(itemId);
     renderInventory();
-    showMessage('You found a small key inside the box.');
-  } else {
-    showMessage('The box is empty.');
+    if (mobileNav && mobileMediaQuery.matches) {
+      setMobilePanel('inventory');
+    }
   }
 }
 
-function tryDoor() {
-  if (gameData.inventory.includes('Key')) {
-    showMessage('You unlocked the door and escaped! Congratulations!');
-    hotspotsDiv.innerHTML = '';
-  } else {
-    showMessage('The door is locked. Perhaps there is a key somewhere.');
+function removeItem(itemId) {
+  state.inventory = state.inventory.filter((id) => id !== itemId);
+  if (state.selectedItemId === itemId) {
+    state.selectedItemId = null;
   }
+  renderInventory();
 }
 
-loadScene(gameData.scene);
-renderInventory();
+function hasItem(itemId) {
+  return state.inventory.includes(itemId);
+}
+
+function displayEnding() {
+  hotspotsContainer.innerHTML = '';
+  const ending = document.createElement('div');
+  ending.className = 'log-entry';
+  ending.innerHTML = '<strong>脱出成功！</strong> Codex 邸からの脱出シナリオをクリアした。SVG や効果音を差し替えて独自の冒険に仕立てよう。';
+  textLog.appendChild(ending);
+  textLog.scrollTop = textLog.scrollHeight;
+}
+
+function initialise() {
+  applyMobileLayout();
+  renderVerbs();
+  renderInventory();
+  logMessage('Codex 脱出プロトタイプへようこそ。書斎を探索し、外へ出る手段を見つけよう。', { highlight: true });
+  changeScene(state.currentScene);
+}
+
+initialise();

--- a/prototype/scenes/foyer.svg
+++ b/prototype/scenes/foyer.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540">
+  <defs>
+    <linearGradient id="foyerWall" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1e2f2b" />
+      <stop offset="1" stop-color="#15201d" />
+    </linearGradient>
+    <linearGradient id="foyerFloor" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#1b1511" />
+      <stop offset="1" stop-color="#0f0a07" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="360" fill="url(#foyerWall)" />
+  <rect y="360" width="960" height="180" fill="url(#foyerFloor)" />
+
+  <!-- Exit Door -->
+  <rect x="360" y="140" width="240" height="280" fill="#1f1a18" stroke="#0d0a09" stroke-width="12" />
+  <rect x="390" y="170" width="180" height="220" fill="#2c2421" />
+  <rect x="430" y="210" width="100" height="140" fill="#151110" />
+  <rect x="450" y="230" width="60" height="100" fill="#080707" />
+  <circle cx="540" cy="280" r="8" fill="#d4ba6b" />
+
+  <!-- Outdoors glow -->
+  <radialGradient id="night" cx="0.5" cy="0.5" r="0.6">
+    <stop offset="0" stop-color="rgba(122, 173, 205, 0.4)" />
+    <stop offset="1" stop-color="rgba(122, 173, 205, 0)" />
+  </radialGradient>
+  <circle cx="480" cy="240" r="180" fill="url(#night)" />
+
+  <!-- Table -->
+  <rect x="120" y="340" width="160" height="120" fill="#3a2a1f" rx="10" />
+  <rect x="660" y="340" width="160" height="120" fill="#3a2a1f" rx="10" />
+
+  <!-- Plants -->
+  <ellipse cx="140" cy="330" rx="50" ry="80" fill="#244a3a" />
+  <ellipse cx="740" cy="330" rx="50" ry="80" fill="#244a3a" />
+
+  <!-- Light -->
+  <radialGradient id="foyerLight" cx="0.5" cy="0.2" r="0.5">
+    <stop offset="0" stop-color="rgba(255, 220, 180, 0.7)" />
+    <stop offset="1" stop-color="rgba(255, 220, 180, 0)" />
+  </radialGradient>
+  <circle cx="480" cy="120" r="200" fill="url(#foyerLight)" />
+</svg>

--- a/prototype/scenes/hallway.svg
+++ b/prototype/scenes/hallway.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540">
+  <defs>
+    <linearGradient id="hallWall" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#233242" />
+      <stop offset="1" stop-color="#131d29" />
+    </linearGradient>
+    <linearGradient id="hallFloor" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#1f2126" />
+      <stop offset="1" stop-color="#0f1013" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="360" fill="url(#hallWall)" />
+  <rect y="360" width="960" height="180" fill="url(#hallFloor)" />
+
+  <!-- Door back to study -->
+  <rect x="60" y="160" width="120" height="240" fill="#2f1d16" stroke="#120904" stroke-width="6" />
+  <circle cx="162" cy="300" r="7" fill="#cba95e" />
+
+  <!-- Crate -->
+  <rect x="320" y="320" width="180" height="120" fill="#59442e" rx="8" />
+  <rect x="320" y="300" width="180" height="28" fill="#6b5139" rx="6" />
+  <line x1="320" y1="360" x2="500" y2="360" stroke="#2f251a" stroke-width="6" />
+
+  <!-- Gate to foyer -->
+  <rect x="700" y="150" width="150" height="250" fill="#1a1d24" stroke="#0a0d12" stroke-width="10" />
+  <g stroke="#3b4a64" stroke-width="14" stroke-linecap="round" opacity="0.8">
+    <line x1="720" y1="170" x2="830" y2="170" />
+    <line x1="720" y1="210" x2="830" y2="210" />
+    <line x1="720" y1="250" x2="830" y2="250" />
+    <line x1="720" y1="290" x2="830" y2="290" />
+    <line x1="720" y1="330" x2="830" y2="330" />
+  </g>
+  <circle cx="828" cy="300" r="10" fill="#c0a45a" />
+
+  <!-- Wall lamp -->
+  <ellipse cx="500" cy="200" rx="40" ry="80" fill="#161f2a" stroke="#3b4a64" stroke-width="6" />
+  <radialGradient id="hallLight" cx="0.55" cy="0.15" r="0.5">
+    <stop offset="0" stop-color="rgba(255, 206, 120, 0.6)" />
+    <stop offset="1" stop-color="rgba(255, 206, 120, 0)" />
+  </radialGradient>
+  <circle cx="520" cy="190" r="200" fill="url(#hallLight)" />
+</svg>

--- a/prototype/scenes/study.svg
+++ b/prototype/scenes/study.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540">
+  <defs>
+    <linearGradient id="wall" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2b2f47" />
+      <stop offset="1" stop-color="#1b1f33" />
+    </linearGradient>
+    <linearGradient id="floor" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#2f1e18" />
+      <stop offset="1" stop-color="#22140f" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="360" fill="url(#wall)" />
+  <rect y="360" width="960" height="180" fill="url(#floor)" />
+
+  <!-- Desk -->
+  <rect x="80" y="300" width="240" height="140" fill="#5d3b29" rx="8" />
+  <rect x="80" y="280" width="240" height="36" fill="#704530" rx="6" />
+  <rect x="120" y="320" width="80" height="36" fill="#40261a" rx="4" />
+  <rect x="220" y="320" width="60" height="36" fill="#40261a" rx="4" />
+
+  <!-- Chair -->
+  <rect x="140" y="360" width="100" height="120" fill="#3d2d28" rx="10" opacity="0.7" />
+
+  <!-- Painting -->
+  <rect x="360" y="120" width="180" height="220" fill="#5a433d" rx="10" stroke="#b88a54" stroke-width="12" />
+  <rect x="380" y="140" width="140" height="180" fill="#1f3248" />
+
+  <!-- Shelves -->
+  <rect x="640" y="170" width="210" height="230" fill="#3b2a1f" rx="12" />
+  <rect x="655" y="190" width="180" height="28" fill="#2c1d15" />
+  <rect x="655" y="240" width="180" height="28" fill="#2c1d15" />
+  <rect x="655" y="290" width="180" height="28" fill="#2c1d15" />
+  <rect x="655" y="340" width="180" height="28" fill="#2c1d15" />
+  <g fill="#c06a4b" opacity="0.8">
+    <rect x="665" y="195" width="40" height="18" />
+    <rect x="715" y="195" width="40" height="18" />
+    <rect x="765" y="195" width="40" height="18" />
+    <rect x="665" y="245" width="40" height="18" />
+    <rect x="715" y="245" width="40" height="18" />
+    <rect x="765" y="245" width="40" height="18" />
+    <rect x="665" y="295" width="40" height="18" />
+    <rect x="715" y="295" width="40" height="18" />
+    <rect x="765" y="295" width="40" height="18" />
+    <rect x="665" y="345" width="40" height="18" />
+    <rect x="715" y="345" width="40" height="18" />
+    <rect x="765" y="345" width="40" height="18" />
+  </g>
+
+  <!-- Door -->
+  <rect x="820" y="160" width="90" height="240" fill="#38231a" stroke="#150d09" stroke-width="6" />
+  <circle cx="892" cy="300" r="8" fill="#caa85a" />
+
+  <!-- Candle light -->
+  <radialGradient id="light" cx="0.15" cy="0.2" r="0.6">
+    <stop offset="0" stop-color="rgba(255, 223, 150, 0.55)" />
+    <stop offset="1" stop-color="rgba(255, 223, 150, 0)" />
+  </radialGradient>
+  <circle cx="160" cy="160" r="180" fill="url(#light)" />
+  <circle cx="740" cy="160" r="180" fill="url(#light)" />
+</svg>

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -1,53 +1,368 @@
+:root {
+  --bg: #11131a;
+  --panel: #1b1e28;
+  --accent: #efc94c;
+  --accent-dark: #c19a31;
+  --text: #f7f7ff;
+  --muted: #9ba0b5;
+  --danger: #f05d5e;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: Arial, sans-serif;
-  background: #222;
-  color: #eee;
   margin: 0;
-  padding: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: radial-gradient(circle at top, #1b233a, var(--bg));
+  color: var(--text);
+  min-height: 100vh;
 }
+
 #game {
-  max-width: 800px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 20px;
+  padding: 1.5rem;
 }
+
+#mobile-nav {
+  display: none;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+}
+
+.mobile-tab {
+  padding: 0.65rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(239, 201, 76, 0.35);
+  background: rgba(239, 201, 76, 0.1);
+  color: var(--text);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.mobile-tab.active,
+.mobile-tab[aria-pressed='true'] {
+  background: rgba(239, 201, 76, 0.45);
+  border-color: rgba(239, 201, 76, 0.85);
+  color: #141722;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 2.25rem;
+  letter-spacing: 0.05em;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(160px, 200px) minmax(420px, 1fr) minmax(220px, 280px);
+  gap: 1rem;
+}
+
+#actions-panel,
+#sidebar,
+#scene-wrapper {
+  background: rgba(27, 30, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+#inventory,
+#journal {
+  margin-bottom: 1rem;
+}
+
 #scene-container {
   position: relative;
-  width: 640px;
-  height: 360px;
-  margin: 0 auto;
-  border: 2px solid #555;
-  background: #000;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
 }
+
 #scene-image {
   width: 100%;
-  height: 100%;
   display: block;
+  background: #05070d;
 }
+
+#scene-caption {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+#hotspots {
+  position: absolute;
+  inset: 0;
+}
+
 .hotspot {
   position: absolute;
-  border: 2px solid rgba(255, 0, 0, 0.5);
+  border: 2px solid rgba(239, 201, 76, 0.6);
+  border-radius: 8px;
+  background: rgba(239, 201, 76, 0.1);
   cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
-#ui {
-  margin-top: 10px;
+
+.hotspot:hover,
+.hotspot:focus-visible {
+  background: rgba(239, 201, 76, 0.25);
+  border-color: rgba(239, 201, 76, 0.9);
 }
-#inventory {
-  margin-bottom: 10px;
+
+.hotspot::after {
+  content: attr(data-name);
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  transform: translate(-50%, 4px);
+  background: rgba(5, 7, 13, 0.9);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.7rem;
+  white-space: nowrap;
+  color: var(--text);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
 }
+
+.hotspot:hover::after,
+.hotspot:focus-visible::after {
+  opacity: 1;
+}
+
+h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+}
+
+.button-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.verb-button {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(239, 201, 76, 0.4);
+  border-radius: 10px;
+  background: linear-gradient(135deg, rgba(239, 201, 76, 0.25), rgba(239, 201, 76, 0.05));
+  color: var(--text);
+  font-size: 0.95rem;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.verb-button:hover,
+.verb-button:focus-visible {
+  border-color: rgba(239, 201, 76, 0.85);
+  box-shadow: 0 8px 18px rgba(239, 201, 76, 0.25);
+}
+
+.verb-button.selected {
+  background: linear-gradient(135deg, rgba(239, 201, 76, 0.55), rgba(239, 201, 76, 0.15));
+  color: #0c0f16;
+  font-weight: 600;
+  transform: translateY(-1px);
+}
+
 #inventory-list {
   list-style: none;
+  margin: 0;
   padding: 0;
   display: flex;
-  gap: 10px;
+  flex-direction: column;
+  gap: 0.4rem;
 }
+
 #inventory-list li {
-  border: 1px solid #999;
-  padding: 4px 8px;
-  background: #333;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  background: rgba(255, 255, 255, 0.04);
+  transition: border-color 0.2s ease, background 0.2s ease;
 }
-#text-box {
-  border: 1px solid #999;
-  padding: 10px;
-  background: #111;
-  min-height: 60px;
+
+#inventory-list li.empty {
+  font-style: italic;
+  color: var(--muted);
+  cursor: default;
+  border-style: dashed;
+  background: rgba(255, 255, 255, 0.02);
+  pointer-events: none;
+}
+
+#inventory-list li:hover,
+#inventory-list li:focus-visible {
+  border-color: rgba(239, 201, 76, 0.8);
+}
+
+#inventory-list li.selected {
+  border-color: rgba(239, 201, 76, 1);
+  background: rgba(239, 201, 76, 0.25);
+  color: #0c0f16;
+}
+
+.inventory-name {
+  font-weight: 600;
+}
+
+.inventory-description {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+#text-log {
+  background: rgba(5, 7, 13, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 0.75rem;
+  height: 240px;
+  overflow-y: auto;
+  font-size: 0.85rem;
+  line-height: 1.35;
+}
+
+.log-entry {
+  margin-bottom: 0.65rem;
+}
+
+.log-entry strong {
+  color: var(--accent);
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.75rem;
+  margin-top: 0.75rem;
+  line-height: 1.4;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  #scene-wrapper {
+    order: -1;
+  }
+
+  #inventory-list {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  #inventory-list li {
+    flex: 1 1 45%;
+  }
+
+  #text-log {
+    height: 200px;
+  }
+}
+
+@media (max-width: 720px) {
+  #mobile-nav {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .layout {
+    display: block;
+  }
+
+  #scene-wrapper {
+    margin-bottom: 1.25rem;
+  }
+
+  #actions-panel,
+  #sidebar {
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  #sidebar {
+    display: contents;
+  }
+
+  #actions-panel,
+  #inventory,
+  #journal {
+    display: none;
+  }
+
+  #actions-panel.mobile-active,
+  #inventory.mobile-active,
+  #journal.mobile-active {
+    display: block;
+    background: rgba(27, 30, 40, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  }
+
+  #inventory,
+  #journal {
+    margin-bottom: 0;
+  }
+
+  #inventory.mobile-active,
+  #journal.mobile-active {
+    margin-top: 1rem;
+  }
+
+  .hint {
+    font-size: 0.8rem;
+  }
+
+  #text-log {
+    height: auto;
+    max-height: 50vh;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }


### PR DESCRIPTION
## Summary
- add a mobile navigation bar so phones can swap between the action, inventory, and journal panels without overwhelming the viewport
- implement responsive styles and supporting logic that hides/reveals panels on small screens and focuses the inventory tab when new items are collected
- document how to serve the prototype so a mobile browser on the same network can connect
- localize the prototype interface, scenario text, and README into Japanese to align with the requested adventure plan

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d6f6852f1483249b73c43c0be5c160