### PR TITLE
Improve shareable escape room language controls

### DIFF
--- a/prototype/README.md
+++ b/prototype/README.md
@@ -1,11 +1,27 @@
 # Escape Room Prototype
 
-This directory contains a very simple web-based prototype for a 2D adventure/escape game. Open `index.html` in a web browser to play.
+This directory contains a very simple web-based prototype for a 2D adventure/escape game.
 
-## How it Works
-- The room is represented by a static image (`room.svg`).
-The image is a simple inline SVG so that no binary assets are needed.
+## Play locally
+Open `index.html` in any modern web browser to try the basic prototype with external CSS and JavaScript files.
 
+## Shareable single-file build
+If you want to share the game just by pasting a link, use the `shareable.html` file. All styling, script logic, and art are inline so it runs anywhere with no additional assets.
+
+### Generate a data URL
+You can convert the single HTML file into a `data:` URL that can be dropped directly into a chat message:
+
+```bash
+node tools/make-data-url.mjs shareable.html > url.txt
+```
+
+The resulting string inside `url.txt` starts with `data:text/html;base64,`. Paste that entire string into the chat—most messaging apps will turn it into a clickable link that opens the game immediately in the browser.
+
+### Switch languages through the URL or UI
+The shareable version supports English and Japanese. There is a language toggle built into the page, and the choice is reflected in the fragment so it can be shared. When linking to the hosted HTML use `?lang=en` (default is `ja`); if you are sharing the inlined `data:` URL use `#lang=en` at the end of the string.
+
+## How it works
+- The room art is drawn with inline SVG so no binary assets are required.
 - Clickable hotspots are positioned over the image using absolute positioning.
 - Clicking the box gives you a key that appears in the inventory list.
 - Clicking the door checks the inventory. If you have the key, you escape and the game ends.

--- a/prototype/shareable.html
+++ b/prototype/shareable.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Escape Room Prototype</title>
+  <meta name="description" content="A minimal point-and-click escape room you can share with a single URL.">
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: "Segoe UI", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+    }
+    body {
+      background: radial-gradient(circle at top, #2d3346 0%, #141620 60%, #090a0f 100%);
+      color: #f4f6fb;
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    #game {
+      max-width: 860px;
+      width: 100%;
+      padding: 24px;
+      box-sizing: border-box;
+    }
+    h1 {
+      margin-top: 0;
+      font-weight: 600;
+      text-align: center;
+      letter-spacing: 0.04em;
+    }
+    #scene-container {
+      position: relative;
+      width: 640px;
+      height: 360px;
+      margin: 0 auto;
+      border-radius: 16px;
+      overflow: hidden;
+      border: 2px solid rgba(255, 255, 255, 0.16);
+      backdrop-filter: blur(4px);
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+    }
+    #scene-image {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+    .hotspot {
+      position: absolute;
+      cursor: pointer;
+      outline: none;
+      border-radius: 8px;
+      border: 2px solid rgba(255, 123, 67, 0.45);
+      transition: border-color 0.2s ease, background-color 0.2s ease;
+    }
+    .hotspot:hover,
+    .hotspot:focus-visible {
+      border-color: rgba(255, 199, 120, 0.9);
+      background-color: rgba(255, 183, 77, 0.15);
+    }
+    #ui {
+      margin-top: 18px;
+      display: grid;
+      gap: 12px;
+    }
+    #language-toggle {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+      justify-content: center;
+    }
+    #language-toggle span {
+      font-size: 0.85rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      opacity: 0.8;
+    }
+    #language-toggle .language-buttons {
+      display: inline-flex;
+      gap: 6px;
+      background: rgba(9, 10, 15, 0.6);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 999px;
+      padding: 4px;
+    }
+    #language-toggle button {
+      background: transparent;
+      border: none;
+      color: inherit;
+      font: inherit;
+      padding: 6px 12px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background-color 0.2s ease, color 0.2s ease;
+    }
+    #language-toggle button:focus-visible {
+      outline: 2px solid rgba(255, 199, 120, 0.9);
+      outline-offset: 2px;
+    }
+    #language-toggle button[data-active="true"] {
+      background: rgba(255, 183, 77, 0.15);
+      color: #ffdfa6;
+    }
+    #inventory {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      background: rgba(9, 10, 15, 0.6);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 12px;
+      padding: 16px;
+    }
+    #inventory h3 {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    #inventory-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    #inventory-list li {
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 999px;
+      padding: 6px 12px;
+      background: rgba(255, 255, 255, 0.1);
+      font-size: 0.9rem;
+      letter-spacing: 0.03em;
+    }
+    #text-box {
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      padding: 16px;
+      background: rgba(9, 10, 15, 0.6);
+      min-height: 70px;
+      line-height: 1.5;
+      font-size: 1rem;
+    }
+    footer {
+      margin-top: 14px;
+      text-align: center;
+      font-size: 0.8rem;
+      opacity: 0.8;
+    }
+    footer a {
+      color: inherit;
+    }
+    @media (max-width: 720px) {
+      #scene-container {
+        width: 100%;
+        height: auto;
+        aspect-ratio: 16 / 9;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="game" role="application" aria-live="polite">
+    <h1 data-i18n="title">ミニ脱出ゲーム</h1>
+    <div id="scene-container">
+      <svg id="scene-image" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="sceneTitle sceneDesc">
+        <title id="sceneTitle">Simple escape room</title>
+        <desc id="sceneDesc">A locked wooden door on the right and a metal box on a table in the middle of the room.</desc>
+        <rect width="640" height="360" fill="#2d2f36" />
+        <rect x="0" y="260" width="640" height="100" fill="#24262c" />
+        <rect x="240" y="210" width="120" height="70" rx="6" ry="6" fill="#8e96a4" stroke="#121418" stroke-width="4" />
+        <rect x="250" y="220" width="100" height="50" rx="5" ry="5" fill="#b0b7c6" stroke="#24262c" stroke-width="3" />
+        <rect x="520" y="110" width="90" height="190" rx="8" ry="8" fill="#7c4b24" stroke="#120805" stroke-width="6" />
+        <circle cx="594" cy="210" r="6" fill="#d6a85e" />
+        <rect x="60" y="40" width="520" height="40" rx="12" ry="12" fill="#20222a" opacity="0.35" />
+        <rect x="80" y="60" width="480" height="16" rx="8" ry="8" fill="#2d303a" opacity="0.7" />
+      </svg>
+      <div id="hotspots"></div>
+    </div>
+    <div id="language-toggle" role="group" aria-label="Language selector">
+      <span data-i18n="languageLabel">言語</span>
+      <div class="language-buttons">
+        <button type="button" data-lang="ja" data-active="false">日本語</button>
+        <button type="button" data-lang="en" data-active="false">English</button>
+      </div>
+    </div>
+    <div id="ui">
+      <div id="inventory">
+        <h3 data-i18n="inventory">インベントリ</h3>
+        <ul id="inventory-list"></ul>
+      </div>
+      <div id="text-box"></div>
+    </div>
+    <footer data-i18n="shareHint">URL をそのままシェアすると、誰でもブラウザだけで遊べます。</footer>
+  </div>
+  <script>
+    const localeData = {
+      en: {
+        strings: {
+          title: 'Mini Escape',
+          inventory: 'Inventory',
+          intro: 'You are in a locked room. Explore the space and find a way out.',
+          foundKey: 'Inside the box you discover a small key. It slides into your inventory.',
+          boxEmpty: 'The box is empty now.',
+          doorLocked: 'The door is locked tight. Maybe something in the room can unlock it.',
+          doorUnlocked: 'Click! The key works. You open the door and step out to freedom!',
+          shareHint: 'Share this exact URL to let anyone play instantly in their browser.',
+          languageLabel: 'Language'
+        },
+        items: {
+          key: 'Key'
+        },
+        hotspots: {
+          box: 'Inspect box',
+          door: 'Try the door'
+        },
+        languageNames: {
+          ja: 'Japanese',
+          en: 'English'
+        }
+      },
+      ja: {
+        strings: {
+          title: 'ミニ脱出ゲーム',
+          inventory: 'インベントリ',
+          intro: '鍵のかかった部屋に閉じ込められています。気になる場所を調べて脱出しましょう。',
+          foundKey: '箱の中から小さな鍵を発見しました。インベントリに追加されます。',
+          boxEmpty: '箱の中にはもう何も残っていません。',
+          doorLocked: 'ドアにはしっかり鍵が掛かっています。どこかにヒントがあるはず。',
+          doorUnlocked: 'カチッ。鍵が開きました！ドアを開けて外に出ましょう！',
+          shareHint: 'この URL をそのまま共有すれば、誰でもブラウザだけで遊べます。',
+          languageLabel: '言語'
+        },
+        items: {
+          key: '鍵'
+        },
+        hotspots: {
+          box: '箱を調べる',
+          door: 'ドアを試す'
+        },
+        languageNames: {
+          ja: '日本語',
+          en: '英語'
+        }
+      }
+    };
+
+    function getHashParams() {
+      const hash = window.location.hash.startsWith('#')
+        ? window.location.hash.slice(1)
+        : window.location.hash;
+      return new URLSearchParams(hash);
+    }
+
+    function getInitialLanguage() {
+      const searchParams = new URLSearchParams(window.location.search);
+      const hashParams = getHashParams();
+      const candidate = (searchParams.get('lang') || hashParams.get('lang') || '').toLowerCase();
+      if (candidate && localeData[candidate]) {
+        return candidate;
+      }
+      return 'ja';
+    }
+
+    let currentLang = getInitialLanguage();
+
+    function setHashLang(lang) {
+      const hashParams = getHashParams();
+      if (hashParams.get('lang') === lang) {
+        return;
+      }
+      hashParams.set('lang', lang);
+      const newHash = hashParams.toString();
+      try {
+        const base = window.location.href.split('#')[0];
+        history.replaceState(null, '', newHash ? `${base}#${newHash}` : base);
+      } catch (error) {
+        window.location.hash = newHash;
+      }
+    }
+
+    const textBox = document.getElementById('text-box');
+    const inventoryList = document.getElementById('inventory-list');
+    const hotspotsDiv = document.getElementById('hotspots');
+    const languageButtons = document.querySelectorAll('#language-toggle [data-lang]');
+
+    const gameState = {
+      inventory: [],
+      doorUnlocked: false,
+      messageKey: 'intro'
+    };
+
+    const hotspots = [];
+
+    function getStrings(lang = currentLang) {
+      return localeData[lang]?.strings ?? localeData.ja.strings;
+    }
+
+    function getItems(lang = currentLang) {
+      return localeData[lang]?.items ?? localeData.ja.items;
+    }
+
+    function getHotspotLabels(lang = currentLang) {
+      return localeData[lang]?.hotspots ?? localeData.ja.hotspots;
+    }
+
+    function updateStaticText() {
+      document.documentElement.lang = currentLang;
+      document.querySelectorAll('[data-i18n]').forEach((el) => {
+        const key = el.getAttribute('data-i18n');
+        const strings = getStrings();
+        if (strings[key]) {
+          el.textContent = strings[key];
+        }
+      });
+      languageButtons.forEach((button) => {
+        const lang = button.getAttribute('data-lang');
+        const names = localeData[currentLang]?.languageNames || localeData.ja.languageNames;
+        button.textContent = names[lang] || lang.toUpperCase();
+        button.dataset.active = (lang === currentLang).toString();
+      });
+    }
+
+    function showMessage(messageKey) {
+      const strings = getStrings();
+      if (typeof messageKey === 'string' && strings[messageKey]) {
+        gameState.messageKey = messageKey;
+        textBox.textContent = strings[messageKey];
+      } else {
+        gameState.messageKey = null;
+        textBox.textContent = messageKey;
+      }
+    }
+
+    function renderInventory() {
+      inventoryList.innerHTML = '';
+      const items = getItems();
+      gameState.inventory.forEach((item) => {
+        const li = document.createElement('li');
+        li.textContent = items[item] || item;
+        inventoryList.appendChild(li);
+      });
+    }
+
+    function openBox() {
+      if (!gameState.inventory.includes('key')) {
+        gameState.inventory.push('key');
+        renderInventory();
+        showMessage('foundKey');
+      } else {
+        showMessage('boxEmpty');
+      }
+    }
+
+    function tryDoor() {
+      if (gameState.inventory.includes('key')) {
+        gameState.doorUnlocked = true;
+        showMessage('doorUnlocked');
+        hotspotsDiv.innerHTML = '';
+      } else {
+        showMessage('doorLocked');
+      }
+    }
+
+    function createHotspot({ left, top, width, height, onClick, labelKey }) {
+      const hotspot = document.createElement('button');
+      hotspot.type = 'button';
+      hotspot.className = 'hotspot';
+      hotspot.style.left = left + 'px';
+      hotspot.style.top = top + 'px';
+      hotspot.style.width = width + 'px';
+      hotspot.style.height = height + 'px';
+      hotspot.setAttribute('aria-label', getHotspotLabels()[labelKey] || labelKey);
+      hotspot.addEventListener('click', onClick);
+      hotspotsDiv.appendChild(hotspot);
+      hotspots.push({ element: hotspot, labelKey });
+    }
+
+    createHotspot({
+      left: 250,
+      top: 220,
+      width: 100,
+      height: 60,
+      onClick: openBox,
+      labelKey: 'box'
+    });
+
+    createHotspot({
+      left: 520,
+      top: 120,
+      width: 80,
+      height: 180,
+      onClick: tryDoor,
+      labelKey: 'door'
+    });
+
+    function updateHotspots() {
+      const labels = getHotspotLabels();
+      hotspots.forEach(({ element, labelKey }) => {
+        if (!gameState.doorUnlocked || labelKey !== 'door') {
+          element.setAttribute('aria-label', labels[labelKey] || labelKey);
+        }
+      });
+    }
+
+    function applyLanguage(lang) {
+      if (!localeData[lang]) {
+        return;
+      }
+      currentLang = lang;
+      updateStaticText();
+      renderInventory();
+      updateHotspots();
+      if (gameState.messageKey) {
+        showMessage(gameState.messageKey);
+      }
+      setHashLang(lang);
+    }
+
+    languageButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const lang = button.getAttribute('data-lang');
+        applyLanguage(lang);
+      });
+    });
+
+    window.addEventListener('hashchange', () => {
+      const hashParams = getHashParams();
+      const lang = hashParams.get('lang');
+      if (lang && localeData[lang] && lang !== currentLang) {
+        applyLanguage(lang);
+      }
+    });
+
+    applyLanguage(currentLang);
+    showMessage('intro');
+    renderInventory();
+  </script>
+</body>
+</html>

--- a/prototype/tools/make-data-url.mjs
+++ b/prototype/tools/make-data-url.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+
+async function main() {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    console.error('Usage: node make-data-url.mjs <html-file>');
+    process.exit(1);
+  }
+  const absolutePath = resolve(filePath);
+  const html = await readFile(absolutePath);
+  const base64 = html.toString('base64');
+  const url = `data:text/html;base64,${base64}`;
+  console.log(url);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add an inline language selector to shareable.html so the game can be switched without editing the markup
- localize inventory items, hotspot aria labels, and instructions while keeping the language choice shareable via the URL hash
- clarify the README to explain how to share language-specific data URLs or hosted links

## Testing
- node prototype/tools/make-data-url.mjs prototype/shareable.html | head -c 80

------
https://chatgpt.com/codex/tasks/task_e_68d70d0406d48324aa95fdb09e36f0a4